### PR TITLE
Implement extended stats and improve design

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,12 +1,25 @@
-body {
-  font-family: Arial, sans-serif;
-  margin: 0;
-  padding: 1rem 2rem;
+*{box-sizing:border-box;}
+body{
+  font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  margin:0;
+  padding:1rem;
+  line-height:1.5;
   background:#f5f6fa;
+  color:#111;
 }
 
-h1 {
+h1{
   text-align:center;
+  font-size:1.6rem;
+  font-weight:700;
+  margin:0 0 1rem;
+}
+@media(min-width:600px){
+.chip{width:44px;height:44px;}
+.controls button{width:auto;}
+  body{padding:2rem;}
+  h1{font-size:2rem;}
+  .controls{grid-template-columns:repeat(auto-fit,minmax(200px,1fr));}
 }
 
 .controls{
@@ -26,8 +39,9 @@ h1 {
   font-size:.9rem;
 }
 .controls input{
-  padding:.25rem .5rem;
+  padding:.5rem;
   font-size:1rem;
+  width:100%;
 }
 .key{
   display:flex;
@@ -35,13 +49,20 @@ h1 {
   gap:.5rem;
   font-size:.8rem;
 }
-.key .chip{
-  pointer-events:none;
-}
-button{
-  padding:.5rem 1rem;
-  font-size:1rem;
+.chip{
+  width:40px;
+  height:40px;
+  border-radius:50%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:#fff;
+  border:2px solid #0a84ff;
+  color:#0a84ff;
   cursor:pointer;
+  user-select:none;
+  font-weight:600;
+  touch-action:manipulation;
 }
 .chart-container{
   width:100%;
@@ -54,6 +75,8 @@ button{
   display:block;
 }
 .stats{
+font-size:0.95rem;
+  line-height:1.6;
   max-width:800px;
   margin:0 auto;
   background:#fff;
@@ -86,8 +109,8 @@ pre{
   align-items:center;
 }
 .chip{
-  width:36px;
-  height:36px;
+  width:40px;
+  height:40px;
   border-radius:50%;
   display:flex;
   align-items:center;
@@ -98,6 +121,7 @@ pre{
   cursor:pointer;
   user-select:none;
   font-weight:600;
+  touch-action:manipulation;
 }
 .chip.selected{
   background:#0a84ff;


### PR DESCRIPTION
## Summary
- add ROI, win/loss ratio and streak tracking stats
- modernize layout with mobile-first styling and touch friendly controls

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_684b4bd917b0832d9821098eb32b3746